### PR TITLE
Add recording backup upload/download

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ Features:
   Start and stop recording of DMX data.
   View real-time status updates of the recording process.
   Manage saved recordings.
+  Upload existing recordings and download backups.
  
 Prerequisites
 
@@ -37,10 +38,13 @@ ui_server.py
 This script sets up a Flask server with the following routes:
 
 /: Serves the main web interface.
-/start_recording: Starts recording DMX data.
-/stop_recording: Stops the current recording session.
-/status: Provides the current status of the recording process.
-/recordings: Lists all saved recordings.
+/list_art_files: Lists saved `.art` recordings.
+/record: Starts or stops a recording.
+/play: Begins or stops playback of a recording.
+/rename_file: Renames an existing recording.
+/delete_file: Deletes a recording.
+/download_file/<filename>: Downloads a recording for backup.
+/upload_file: Uploads a recording file to the server.
 The server communicates with OLA to handle the recording and playback of DMX data.
 
 Contributing

--- a/templates/index.html
+++ b/templates/index.html
@@ -54,7 +54,8 @@
             });
             document.getElementById('renameButton').addEventListener('click', renameFile);
             document.getElementById('deleteButton').addEventListener('click', deleteFile);
-            document.getElementById('broadcastButton').addEventListener("click", toggleBroadcast);
+            document.getElementById('downloadButton').addEventListener('click', downloadFile);
+            document.getElementById('uploadButton').addEventListener('click', uploadFile);
         }
 
         function updateRecordingsList() {
@@ -179,6 +180,37 @@
             });
         }
 
+        function downloadFile() {
+            const filename = document.getElementById('playbackSelection').value;
+            if (!filename) return;
+            window.location.href = '/download_file/' + encodeURIComponent(filename);
+        }
+
+        function uploadFile() {
+            const fileInput = document.getElementById('uploadInput');
+            if (fileInput.files.length === 0) {
+                showFeedback('Please select a file to upload.', 'warning');
+                return;
+            }
+            const formData = new FormData();
+            formData.append('file', fileInput.files[0]);
+
+            fetch('/upload_file', {
+                method: 'POST',
+                body: formData
+            })
+            .then(response => response.json())
+            .then(data => {
+                showFeedback(data.message, 'success');
+                fileInput.value = '';
+                updateRecordingsList();
+            })
+            .catch(error => {
+                console.error('Error uploading file:', error);
+                showFeedback('Failed to upload file. ' + error.message, 'danger');
+            });
+        }
+
 
         function showFeedback(message, type) {
             const feedbackAlert = document.getElementById('feedbackAlert');
@@ -221,6 +253,9 @@
             <button id="togglePlaybackButton" class="btn btn-primary">Play</button>
             <button id="renameButton" class="btn btn-warning">Rename</button>
             <button id="deleteButton" class="btn btn-danger">Delete</button>
+            <button id="downloadButton" class="btn btn-info">Download</button>
+            <input type="file" id="uploadInput" class="form-control-file mt-2" accept=".art" />
+            <button id="uploadButton" class="btn btn-secondary mt-1">Upload</button>
         </div>
     </div>
     <script src="controlScript.js" defer></script>

--- a/ui_server.py
+++ b/ui_server.py
@@ -1,4 +1,4 @@
-from flask import Flask, render_template, request, jsonify
+from flask import Flask, render_template, request, jsonify, send_from_directory
 import subprocess
 import os
 import logging
@@ -16,7 +16,7 @@ app = Flask(__name__)
 
 @app.route('/')
 def index():
-    return "Index Page"  # Placeholder for your HTML return
+    return render_template('index.html')
 
 @app.route('/list_art_files')
 def list_art_files():
@@ -87,6 +87,25 @@ def delete_file():
         return jsonify({'message': "File deleted successfully"}), 200
     else:
         return jsonify({'error': "File not found"}), 404
+
+@app.route('/download_file/<path:filename>', methods=['GET'])
+def download_file(filename):
+    file_path = os.path.join(BASE_DIR, filename)
+    if os.path.exists(file_path):
+        return send_from_directory(BASE_DIR, filename, as_attachment=True)
+    return jsonify({'error': 'File not found'}), 404
+
+@app.route('/upload_file', methods=['POST'])
+def upload_file():
+    if 'file' not in request.files:
+        return jsonify({'error': 'No file part'}), 400
+    file = request.files['file']
+    if file.filename == '':
+        return jsonify({'error': 'No selected file'}), 400
+    filename = os.path.basename(file.filename)
+    save_path = os.path.join(BASE_DIR, filename)
+    file.save(save_path)
+    return jsonify({'message': 'File uploaded successfully'}), 200
         
 if __name__ == '__main__':
     app.run(host='0.0.0.0', port=8080)


### PR DESCRIPTION
## Summary
- serve the index HTML directly from Flask
- add download and upload endpoints in `ui_server.py`
- extend the web interface with Upload and Download controls
- document new capabilities in the README

## Testing
- `python3 -m py_compile ui_server.py`


------
https://chatgpt.com/codex/tasks/task_e_685dcf854cb4832b957d0cfe905eb4b2